### PR TITLE
Fix implicit declaration warning for mkdir

### DIFF
--- a/cfm-seriation.c
+++ b/cfm-seriation.c
@@ -3,6 +3,7 @@
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 typedef struct graph_ptr{
 	short cur;


### PR DESCRIPTION
Currently on compiling, this warning is thrown:

```
cfm-seriation.c: In function ‘main’:
cfm-seriation.c:647:3: warning: implicit declaration of function ‘mkdir’ [-Wimplicit-function-declaration]
  647 |   mkdir(dir_name, 0777);
      |   ^~~~~
```
This is an attempt to fix it